### PR TITLE
re-add imports for in-memory-web-api in app.module - commented out

### DIFF
--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -23,6 +23,11 @@ import { RecommendationTableComponent } from './checklist/recommendation-table.c
 import { SelfAssessmentComponent } from './self-assessment.component';
 import { LineGraphComponent } from './line-graph.component';
 
+/**********************************************************************
+import { InMemoryWebApiModule } from 'angular-in-memory-web-api';
+import { InMemoryRxDataService }  from './in-memory-rxdata.service';
+**********************************************************************/
+
 @NgModule({
   imports:      [
     BrowserModule,
@@ -30,6 +35,11 @@ import { LineGraphComponent } from './line-graph.component';
     FormsModule,
     HttpModule,
     JsonpModule
+
+/**********************************************************************
+,  InMemoryWebApiModule.forRoot(InMemoryRxDataService)
+**********************************************************************/
+
      ],
   declarations: [
     AppComponent,


### PR DESCRIPTION
uncomment these 3 lines in appmodule to make in-memory-web-api mock out of http service work for those who don't have a dotNet core server